### PR TITLE
Fix str concatenation error in already_active()

### DIFF
--- a/TealUS_fallback.py
+++ b/TealUS_fallback.py
@@ -24,8 +24,8 @@ def already_active(eid: str, plan_uuid: str) -> bool:
     True  ➜  SIM already has this plan *active* – we can skip.
     False ➜  Plan missing or inactive – we still need to run assign-plan.
     """
-    rid = generate_request_id()
-    info_op = get_esim_info(eid, rid)
+    # get_esim_info now generates its own request_id and returns it
+    info_op, rid = get_esim_info(eid)
     # we need the finished operation-result
     time.sleep(30)
     info = get_operation_result(rid)


### PR DESCRIPTION
## Summary
- handle return value of `get_esim_info` correctly

## Testing
- `python3 -m py_compile TealUS_fallback.py`

------
https://chatgpt.com/codex/tasks/task_e_6841f37ce504833196aae4520cd411aa